### PR TITLE
Add .env-option for disabling repeat alerts

### DIFF
--- a/.env
+++ b/.env
@@ -15,3 +15,6 @@ MAX_DELAY=11
 
 # Variable to decide if a web browser should open automatically (set to false if running on a headless server)
 OPEN_WEB_BROWSER="true"
+
+# Don't repeat alerts when the product was found once
+DONT_REPEAT="True"

--- a/.env
+++ b/.env
@@ -17,4 +17,4 @@ MAX_DELAY=11
 OPEN_WEB_BROWSER="true"
 
 # Don't repeat alerts when the product was found once
-DONT_REPEAT="True"
+DONT_REPEAT="False"

--- a/notifier.py
+++ b/notifier.py
@@ -25,8 +25,8 @@ TELEGRAM_CHAT = getenv('TELEGRAM_CHAT')
 ALERT_DELAY = int(getenv('ALERT_DELAY'))
 MIN_DELAY = int(getenv('MIN_DELAY'))
 MAX_DELAY = int(getenv('MAX_DELAY'))
-OPEN_WEB_BROWSER = getenv('OPEN_WEB_BROWSER') == 'true'
-DONT_REPEAT = getenv('DONT_REPEAT')
+OPEN_WEB_BROWSER = getenv('OPEN_WEB_BROWSER').capitalize() 
+DONT_REPEAT = getenv('DONT_REPEAT').capitalize() 
 
 with open('sites.json', 'r') as f:
     sites = json.load(f)
@@ -85,9 +85,9 @@ def discord_notification(product, url):
         try:
             result.raise_for_status()
         except requests.exceptions.HTTPError as err:
-            print(err)
+            print("Discord:\t"+str(err))
         else:
-            print("Payload delivered successfully, code {}.".format(result.status_code))
+            print("Discord:\tPayload delivered successfully, code {}.".format(result.status_code))
             
 def telegram_notification(product, url):
     if USE_TELEGRAM: 
@@ -100,9 +100,9 @@ def telegram_notification(product, url):
         try:
             result.raise_for_status()
         except requests.exceptions.HTTPError as err:
-            print(err)
+            print("Telegram:\t"+str(err))
         else:
-            print("Payload delivered successfully, code {}.".format(result.status_code))
+            print("Telegram:\tPayload delivered successfully, code {}.".format(result.status_code))
 
 def urllib_get(url):
     # for regular sites
@@ -150,11 +150,11 @@ def main():
                 index = html.upper().find(keyword.upper())
                 if alert_on_found and index != -1:
                     alert(site)
-                    if DONT_REPEAT:
+                    if DONT_REPEAT == 'True':
                         site["enabled"] = False
                 elif not alert_on_found and index == -1:
                     alert(site)
-                    if DONT_REPEAT:
+                    if DONT_REPEAT == 'True':
                         site["enabled"] = False
 
                 base_sleep = 1


### PR DESCRIPTION
Add .env-option for disabling repeat alerts:
- new .env-variable to disable sites once they've triggered an alert
- end While-loop if all sites are disabled

default is still endless repeats